### PR TITLE
Patch netapp_net_port provider self.instances and self.prefetch

### DIFF
--- a/lib/puppet/provider/netapp_net_port/cmode.rb
+++ b/lib/puppet/provider/netapp_net_port/cmode.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:netapp_net_port).provide(:cmode, :parent => Puppet::Provider:
       node_port_name = node_name1 + "@" + port_name1
 
       net_port_info_hash = {
-        :node_port_name => node_port_name,
+        :name              => node_port_name,
         :flowcontrol_admin => result.child_get_string('administrative-flowcontrol'),
         :ensure            => :present
       }
@@ -33,9 +33,10 @@ Puppet::Type.type(:netapp_net_port).provide(:cmode, :parent => Puppet::Provider:
 
   def self.prefetch(resources)
     Puppet.debug("Puppet::Provider::Netapp_net_port.cmode: Got to self.prefetch.")
-    instances.each do |prov|
-      if resource = resources[prov.node_port_name]
-        resource.provider = prov
+    net_ports = instances
+    resources.each do |name, resource|
+      if provider = net_ports.find { |net_port| net_port.name == resource[:node_port_name] }
+        resources[name].provider = provider
       end
     end
   end


### PR DESCRIPTION
- self.instance should return :name for alternately named namevars
- self.prefetch should match on the alternately named properties